### PR TITLE
fix array overrun panic bug, #13

### DIFF
--- a/irc/commands.go
+++ b/irc/commands.go
@@ -327,6 +327,9 @@ func ParseJoinCommand(args []string) (Command, error) {
 	keys := make([]string, len(channels))
 	if len(args) > 1 {
 		for i, key := range strings.Split(args[1], ",") {
+			if i >= len(channels) {
+				break
+			}
 			keys[i] = key
 		}
 	}


### PR DESCRIPTION
Before:

```
2015/06/06 18:24:30 127.0.0.1:45801 ← :irc.example.com NOTICE edmund :user edmund has global:i
2015/06/06 18:24:31 127.0.0.1:45801 → join #argh 1,2,3,4
panic: runtime error: index out of range
```

With this patch:

```
2015/06/06 18:25:28 127.0.0.1:45802 ← :irc.example.com NOTICE edmund :user edmund has global:i
2015/06/06 18:25:30 127.0.0.1:45802 → join #argh 1,2,3,4
2015/06/06 18:25:30 127.0.0.1:45802 ← :edmund!edmund@localhost JOIN #argh
2015/06/06 18:25:30 127.0.0.1:45802 ← :irc.example.com 353 edmund = #argh :@edmund
2015/06/06 18:25:30 127.0.0.1:45802 ← :irc.example.com 366 edmund #argh :End of NAMES list
2015/06/06 18:25:30 127.0.0.1:45802 → MODE #argh
2015/06/06 18:25:30 127.0.0.1:45802 ← :irc.example.com 324 edmund #argh 
2015/06/06 18:25:30 127.0.0.1:45802 → WHO #argh
2015/06/06 18:25:30 127.0.0.1:45802 ← :irc.example.com 352 edmund #argh edmund localhost irc.example.com edmund H@ :0 Edmund Huber
2015/06/06 18:25:30 127.0.0.1:45802 ← :irc.example.com 315 edmund #argh :End of WHO list
2015/06/06 18:25:30 127.0.0.1:45802 → MODE #argh b
2015/06/06 18:25:30 127.0.0.1:45802 ← :irc.example.com 368 edmund #argh :End of channel ban list
```
