### PR TITLE
irc: Switch to golang.org versions, not google code versions of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ ergonomadic run -conf ergonomadic.conf
 * Niels Freier, added WebSocket support, <https://github.com/stumpyfr>
 * apologies to anyone I forgot.
 
-[go-crypto]: http://godoc.org/code.google.com/p/go.crypto
+[go-crypto]: https://godoc.org/golang.org/x/crypto
 [go-sqlite]: https://github.com/mattn/go-sqlite3
 [proxy-proto]: http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt

--- a/irc/password.go
+++ b/irc/password.go
@@ -1,7 +1,7 @@
 package irc
 
 import (
-	"code.google.com/p/go.crypto/bcrypt"
+	"golang.org/x/crypto/bcrypt"
 	"encoding/base64"
 	"errors"
 )

--- a/irc/strings.go
+++ b/irc/strings.go
@@ -1,7 +1,7 @@
 package irc
 
 import (
-	"code.google.com/p/go.text/unicode/norm"
+	"golang.org/x/text/unicode/norm"
 	"regexp"
 	"strings"
 )


### PR DESCRIPTION
This has a few advantages:
- the google code versions are no longer maintained
- the google code versions are using mercurial (which I don't have installed)

(NB: please go easy on me. this is the first time I've actually poked a go-using project, so I'm not fully sure what I'm doing yet. Seems to build and runs OK, and I can make and use passwords, but I haven't tested extensively.)
