### PR TITLE
Add optional Go-based SSL

### DIFF
--- a/ergonomadic.conf
+++ b/ergonomadic.conf
@@ -13,3 +13,8 @@ password = "JDJhJDA0JEhkcm10UlNFRkRXb25iOHZuSDVLZXVBWlpyY0xyNkQ4dlBVc1VMWVk1LlFj
 
 [theater "#ghostbusters"]
 password = "JDJhJDA0JG0yY1h4cTRFUHhkcjIzN2p1M2Nvb2VEYjAzSHh4eTB3YkZ0VFRLV1ZPVXdqeFBSRUtmRlBT" ; 'venkman'
+
+[ssllistener ":6697"]
+enabled = true
+sslkey = test.key
+sslcert = test.crt

--- a/ergonomadic.conf
+++ b/ergonomadic.conf
@@ -3,6 +3,7 @@ name = "irc.example.com" ; required, usually a hostname
 database = "ergonomadic.db" ; path relative to this file
 listen = "localhost:6667" ; see `net.Listen` for examples
 listen = "[::1]:6667" ; multiple `listen`s are allowed.
+listen = ":6697"
 wslisten = ":8080" ; websocket listen
 log = "debug" ; error, warn, info, debug
 motd = "motd.txt" ; path relative to this file
@@ -15,6 +16,5 @@ password = "JDJhJDA0JEhkcm10UlNFRkRXb25iOHZuSDVLZXVBWlpyY0xyNkQ4dlBVc1VMWVk1LlFj
 password = "JDJhJDA0JG0yY1h4cTRFUHhkcjIzN2p1M2Nvb2VEYjAzSHh4eTB3YkZ0VFRLV1ZPVXdqeFBSRUtmRlBT" ; 'venkman'
 
 [ssllistener ":6697"]
-enabled = true
 sslkey = test.key
 sslcert = test.crt

--- a/irc/config.go
+++ b/irc/config.go
@@ -13,7 +13,6 @@ type PassConfig struct {
 
 // SSLListenConfig defines configuration options for listening on SSL
 type SSLListenConfig struct {
-	Enabled bool
 	SSLCert string
 	SSLKey  string
 }


### PR DESCRIPTION
This PR adds golang based SSL, using the `crypto/tls` package, to allow the server to accept SSL connections directly.

This PR does not remove any mechanisms for proxying SSL requests, as that is the recommended way to use SSL for ergonomadic.
