### PR TITLE
Allow empty/blank passwords

### DIFF
--- a/irc/password.go
+++ b/irc/password.go
@@ -1,13 +1,15 @@
 package irc
 
 import (
-	"golang.org/x/crypto/bcrypt"
 	"encoding/base64"
 	"errors"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 var (
-	EmptyPasswordError = errors.New("empty password")
+	EmptyPasswordError   = errors.New("empty password")
+	InvalidPasswordError = errors.New("invalid encrypted password")
 )
 
 func GenerateEncodedPassword(passwd string) (encoded string, err error) {
@@ -25,10 +27,12 @@ func GenerateEncodedPassword(passwd string) (encoded string, err error) {
 
 func DecodePassword(encoded string) (decoded []byte, err error) {
 	if encoded == "" {
-		err = EmptyPasswordError
 		return
 	}
 	decoded, err = base64.StdEncoding.DecodeString(encoded)
+	if len(decoded) < 60 {
+		err = InvalidPasswordError
+	}
 	return
 }
 


### PR DESCRIPTION
This PR adds support for making the "password" optional for connecting to an IRC server. If the password is not provided, the server will not issue a `EmptyPasswordError`, but will instead issue a `InvalidPasswordError` if the base64 decoded password is < 60 bytes
