### PR TITLE
Add persistent clients table

### DIFF
--- a/ergonomadic.conf
+++ b/ergonomadic.conf
@@ -13,3 +13,8 @@ password = "JDJhJDA0JEhkcm10UlNFRkRXb25iOHZuSDVLZXVBWlpyY0xyNkQ4dlBVc1VMWVk1LlFj
 
 [theater "#ghostbusters"]
 password = "JDJhJDA0JG0yY1h4cTRFUHhkcjIzN2p1M2Nvb2VEYjAzSHh4eTB3YkZ0VFRLV1ZPVXdqeFBSRUtmRlBT" ; 'venkman'
+
+[ssllistener ":6697"]
+enabled = true
+sslkey = test.key
+sslcert = test.crt


### PR DESCRIPTION
This PR persists the `clients` table to the on-disk database, instead of an in-memory one.

Additional future work might include:
1. Nick tracking and registration (ala services?)
2. Persistent connection bans and restrictions
