### PR TITLE
Use file-based database for client table

### DIFF
--- a/irc/client_lookup_set.go
+++ b/irc/client_lookup_set.go
@@ -46,10 +46,10 @@ type ClientLookupSet struct {
 	db     *ClientDB
 }
 
-func NewClientLookupSet() *ClientLookupSet {
+func NewClientLookupSet(db string) *ClientLookupSet {
 	return &ClientLookupSet{
 		byNick: make(map[Name]*Client),
-		db:     NewClientDB(),
+		db:     NewClientDB(db),
 	}
 }
 
@@ -131,9 +131,9 @@ type ClientDB struct {
 	db *sql.DB
 }
 
-func NewClientDB() *ClientDB {
+func NewClientDB(db_path string) *ClientDB {
 	db := &ClientDB{
-		db: OpenDB(":memory:"),
+		db: OpenDB(db_path),
 	}
 	stmts := []string{
 		`CREATE TABLE client (
@@ -145,7 +145,7 @@ func NewClientDB() *ClientDB {
 	}
 	for _, stmt := range stmts {
 		_, err := db.db.Exec(stmt)
-		if err != nil {
+		if err != nil && !strings.HasSuffix(err.Error(), "already exists") {
 			log.Fatal("NewClientDB: ", stmt, err)
 		}
 	}

--- a/irc/server.go
+++ b/irc/server.go
@@ -49,7 +49,7 @@ var (
 func NewServer(config *Config) *Server {
 	server := &Server{
 		channels:  make(ChannelNameMap),
-		clients:   NewClientLookupSet(),
+		clients:   NewClientLookupSet(config.Server.Database),
 		commands:  make(chan Command),
 		ctime:     time.Now(),
 		db:        OpenDB(config.Server.Database),


### PR DESCRIPTION
This PR persists the clients table to the on-disk database, instead of an in-memory one.

Additional future work might include:
1. Nick tracking and registration (ala services?)
2. Persistent connection bans and restrictions
