### PR TITLE
Don't restrict MOTD lines to 80 chars

### DIFF
--- a/irc/server.go
+++ b/irc/server.go
@@ -283,17 +283,7 @@ func (server *Server) MOTD(client *Client) {
 		}
 		line = strings.TrimRight(line, "\r\n")
 
-		if len(line) > 80 {
-			for len(line) > 80 {
-				client.RplMOTD(line[0:80])
-				line = line[80:]
-			}
-			if len(line) > 0 {
-				client.RplMOTD(line)
-			}
-		} else {
-			client.RplMOTD(line)
-		}
+		client.RplMOTD(line)
 	}
 	client.RplMOTDEnd()
 }


### PR DESCRIPTION
This limit hasn't been respected by real networks or IRCds for a while now. I can run around and get stats on what networks advertise these days if desired, but I don't think the limit is necessary for today's clients.

I ran into this causing issues when I was trying to use shiny utf-8 characters for [this motd](https://raw.githubusercontent.com/DanielOaks/oragono/master/oragono.motd), it was restricting them to 80 chars and chopping characters in half.

Perhaps it would be good to limit it to the IRC line length, 512 characters and all, but I'd honestly consider that something the network op should worry about rather than us in the server software itself.
