### PR TITLE
strings: Disallow nicknames that mess with the protocol in bad ways

### DIFF
--- a/irc/strings.go
+++ b/irc/strings.go
@@ -1,9 +1,10 @@
 package irc
 
 import (
-	"golang.org/x/text/unicode/norm"
 	"regexp"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 var (
@@ -35,7 +36,15 @@ func (name Name) IsChannel() bool {
 }
 
 func (name Name) IsNickname() bool {
-	return NicknameExpr.MatchString(name.String())
+	namestr := name.String()
+	// * is used for unregistered clients
+	// , is used as a separator by the protocol
+	// # is a channel prefix
+	// @+ are channel membership prefixes
+	if namestr == "*" || strings.Contains(namestr, ",") || strings.Contains("#@+", string(namestr[0])) {
+		return false
+	}
+	return NicknameExpr.MatchString(namestr)
 }
 
 // conversions


### PR DESCRIPTION
These nicknames are quite bad and break the protocol in interesting ways. Disallowing them is a good thing to do. It also disallows silly things like fullwidth commas (`，`) that get converted into `,` natively because of the name normalisation.
