### PR TITLE
CAP command fixes

### DIFF
--- a/irc/nickname.go
+++ b/irc/nickname.go
@@ -13,10 +13,6 @@ func (m *NickCommand) HandleRegServer(s *Server) {
 		return
 	}
 
-	if client.capState == CapNegotiating {
-		client.capState = CapNegotiated
-	}
-
 	if m.nickname == "" {
 		client.ErrNoNicknameGiven()
 		return

--- a/irc/reply.go
+++ b/irc/reply.go
@@ -179,7 +179,10 @@ func RplKill(client *Client, target *Client, comment Text) string {
 }
 
 func RplCap(client *Client, subCommand CapSubCommand, arg interface{}) string {
-	return NewStringReply(nil, CAP, "%s %s :%s", client.Nick(), subCommand, arg)
+	// client.server needs to be here to workaround a parsing bug in weechat 1.4
+	// and let it connect to the server (otherwise it doesn't respond to the CAP
+	// message with anything and just hangs on connection)
+	return NewStringReply(client.server, CAP, "%s %s :%s", client.Nick(), subCommand, arg)
 }
 
 // numeric replies

--- a/irc/server.go
+++ b/irc/server.go
@@ -356,9 +356,6 @@ func (msg *RFC2812UserCommand) HandleRegServer(server *Server) {
 
 func (msg *UserCommand) setUserInfo(server *Server) {
 	client := msg.Client()
-	if client.capState == CapNegotiating {
-		client.capState = CapNegotiated
-	}
 
 	server.clients.Remove(client)
 	client.username, client.realname = msg.username, msg.realname


### PR DESCRIPTION
This PR contains a few minor fixes for the `CAP` command, and adds a workaround to let Weechat (and possibly other clients) actually use `CAP` negotiation when connecting to the server (which is required when registration is now properly suspended during CAP negotiation). If you'd like this squashed, let me know.
