### PR TITLE
MODE: Parse newer syntax, handle parameters correctly, don't send unnecessary NOTICE

### DIFF
--- a/irc/commands.go
+++ b/irc/commands.go
@@ -450,25 +450,29 @@ func ParseUserModeCommand(nickname Name, args []string) (Command, error) {
 		changes:  make(ModeChanges, 0),
 	}
 
-	for _, modeChange := range args {
-		if len(modeChange) == 0 {
+	// account for MODE command with no args to list things
+	if len(args) < 1 {
+		// don't do any further processing
+		return cmd, nil
+	}
+
+	modeArg := args[0]
+	op := ModeOp(modeArg[0])
+	if (op == Add) || (op == Remove) {
+		modeArg = modeArg[1:]
+	} else {
+		return nil, ErrParseCommand
+	}
+
+	for _, mode := range modeArg {
+		if mode == '-' || mode == '+' {
+			op = ModeOp(mode)
 			continue
 		}
-		op := ModeOp(modeChange[0])
-		if (op != Add) && (op != Remove) {
-			return nil, ErrParseCommand
-		}
-
-		for _, mode := range modeChange[1:] {
-			if mode == '-' || mode == '+' {
-				op = ModeOp(mode)
-				continue
-			}
-			cmd.changes = append(cmd.changes, &ModeChange{
-				mode: UserMode(mode),
-				op:   op,
-			})
-		}
+		cmd.changes = append(cmd.changes, &ModeChange{
+			mode: UserMode(mode),
+			op:   op,
+		})
 	}
 
 	return cmd, nil
@@ -531,41 +535,44 @@ func ParseChannelModeCommand(channel Name, args []string) (Command, error) {
 		changes: make(ChannelModeChanges, 0),
 	}
 
-	for len(args) > 0 {
-		if len(args[0]) == 0 {
-			args = args[1:]
+	// account for MODE command with no args to list things
+	if len(args) < 1 {
+		// don't do any further processing
+		return cmd, nil
+	}
+
+	modeArg := args[0]
+	op := ModeOp(modeArg[0])
+	if (op == Add) || (op == Remove) {
+		modeArg = modeArg[1:]
+	} else {
+		return nil, ErrParseCommand
+	}
+
+	currentArgIndex := 1
+
+	for _, mode := range modeArg {
+		if mode == '-' || mode == '+' {
+			op = ModeOp(mode)
 			continue
 		}
-
-		modeArg := args[0]
-		op := ModeOp(modeArg[0])
-		if (op == Add) || (op == Remove) {
-			modeArg = modeArg[1:]
-		} else {
-			op = List
+		change := &ChannelModeChange{
+			mode: ChannelMode(mode),
+			op:   op,
 		}
-
-		skipArgs := 1
-		for _, mode := range modeArg {
-			if mode == '-' || mode == '+' {
-				op = ModeOp(mode)
+		switch change.mode {
+		// TODO(dan): separate this into the type A/B/C/D args and use those lists here
+		case Key, BanMask, ExceptMask, InviteMask, UserLimit,
+			ChannelOperator, ChannelCreator, Voice:
+			if len(args) > currentArgIndex {
+				change.arg = args[currentArgIndex]
+				currentArgIndex++
+			} else {
+				// silently skip this mode
 				continue
 			}
-			change := &ChannelModeChange{
-				mode: ChannelMode(mode),
-				op:   op,
-			}
-			switch change.mode {
-			case Key, BanMask, ExceptMask, InviteMask, UserLimit,
-				ChannelOperator, ChannelCreator, Voice:
-				if len(args) > skipArgs {
-					change.arg = args[skipArgs]
-					skipArgs += 1
-				}
-			}
-			cmd.changes = append(cmd.changes, change)
 		}
-		args = args[skipArgs:]
+		cmd.changes = append(cmd.changes, change)
 	}
 
 	return cmd, nil

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -150,7 +150,6 @@ func (m *ModeCommand) HandleServer(s *Server) {
 	} else if client == target {
 		client.RplUModeIs(client)
 	}
-	client.Reply(RplCurrentMode(client, target))
 }
 
 func (msg *ChannelModeCommand) HandleServer(server *Server) {

--- a/irc/reply.go
+++ b/irc/reply.go
@@ -123,21 +123,6 @@ func RplModeChanges(client *Client, target *Client, changes ModeChanges) string 
 	return NewStringReply(client, MODE, "%s :%s", target.Nick(), changes)
 }
 
-func RplCurrentMode(client *Client, target *Client) string {
-	globalFlags := "global:"
-	for mode, _ := range target.flags {
-		globalFlags += mode.String()
-	}
-
-	perChannelFlags := ""
-	for channel, _ := range target.channels {
-		perChannelFlags += fmt.Sprintf(" %s:%s", channel.name, channel.members[target])
-	}
-
-	response := NewText(fmt.Sprintf("user %s has %s%s", target.nick, globalFlags, perChannelFlags))
-	return RplNotice(client.server, client, response)
-}
-
 func RplChannelMode(client *Client, channel *Channel,
 	changes ChannelModeChanges) string {
 	return NewStringReply(client, MODE, "%s %s", channel, changes)


### PR DESCRIPTION
This fixes a few strange behaviours about the `MODE` command.

This PR extends the `MODE` command to parse the newer syntax that allows modestrings to both remove and add modes in the same string. For instance:
- `/mode dan +i-o`
- `/mode #chan +vv-o george bunny dan`

It also handles unused parameters correctly. Before, if it encountered a parameter that was unused, it would loop through those parameters as though they were modestrings as well, which is incorrect. Now it only parses the correct parameter as a modestring and ignores the unused params.

Upon discovering the modes of a channel/user (or changing user modes), Ergo would respond with a `NOTICE` like this:
`-- oragono.test: user dan has global:io #testchan:Oo #services: #a:Oo #test:Oo`

This is already covered by the `RPL_CHANNELMODEIS` and `RPL_UMODEIS` numerics and the standard `MODE` messages already sent. A notice like that may be useful for debugging purposes but isn't required for standard operation and just clutters things.
