### PR TITLE
Initial RPL_ISUPPORT numeric support

### DIFF
--- a/ergonomadic.yaml
+++ b/ergonomadic.yaml
@@ -1,4 +1,11 @@
 # ergonomadic IRCd config
+
+# network configuration
+network:
+    # name of the network
+    name: ErgonomadicTest
+
+# server configuration
 server:
     # server name
     name: ergonomadic.test

--- a/irc/config.go
+++ b/irc/config.go
@@ -21,14 +21,18 @@ func (conf *PassConfig) PasswordBytes() []byte {
 }
 
 type Config struct {
+	Network struct {
+		Name string
+	}
+
 	Server struct {
 		PassConfig
+		Name     string
 		Database string
 		Listen   []string
 		Wslisten string
 		Log      string
 		MOTD     string
-		Name     string
 	}
 
 	Operator map[string]*PassConfig
@@ -67,6 +71,9 @@ func LoadConfig(filename string) (config *Config, err error) {
 		return nil, err
 	}
 
+	if config.Network.Name == "" {
+		return nil, errors.New("Network name missing")
+	}
 	if config.Server.Name == "" {
 		return nil, errors.New("Server name missing")
 	}

--- a/irc/constants.go
+++ b/irc/constants.go
@@ -44,7 +44,8 @@ const (
 	RPL_YOURHOST          NumericCode = 2
 	RPL_CREATED           NumericCode = 3
 	RPL_MYINFO            NumericCode = 4
-	RPL_BOUNCE            NumericCode = 5
+	RPL_ISUPPORT          NumericCode = 5
+	RPL_BOUNCE            NumericCode = 10
 	RPL_TRACELINK         NumericCode = 200
 	RPL_TRACECONNECTING   NumericCode = 201
 	RPL_TRACEHANDSHAKE    NumericCode = 202

--- a/irc/isupport.go
+++ b/irc/isupport.go
@@ -1,0 +1,66 @@
+package irc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ISupportList holds a list of ISUPPORT tokens
+type ISupportList struct {
+	Tokens      map[string]*string
+	CachedReply []string
+}
+
+// NewISupportList returns a new ISupportList
+func NewISupportList() *ISupportList {
+	var il ISupportList
+	il.Tokens = make(map[string]*string)
+	il.CachedReply = make([]string, 0)
+	return &il
+}
+
+// Add adds an RPL_ISUPPORT token to our internal list
+func (il *ISupportList) Add(name string, value string) {
+	il.Tokens[name] = &value
+}
+
+// AddNoValue adds an RPL_ISUPPORT token that does not have a value
+func (il *ISupportList) AddNoValue(name string) {
+	il.Tokens[name] = nil
+}
+
+// RegenerateCachedReply regenerates the cached RPL_ISUPPORT reply
+func (il *ISupportList) RegenerateCachedReply() {
+	il.CachedReply = make([]string, 0)
+	maxlen := 400      // Max length of a single ISUPPORT token line
+	var length int     // Length of the current cache
+	var cache []string // Token list cache
+
+	for name, value := range il.Tokens {
+		var token string
+		if value == nil {
+			token = name
+		} else {
+			token = fmt.Sprintf("%s=%s", name, *value)
+		}
+
+		if len(token)+length <= maxlen {
+			// account for the space separating tokens
+			if len(cache) > 0 {
+				length++
+			}
+			cache = append(cache, token)
+			length += len(token)
+		}
+
+		if len(cache) == 13 || len(token)+length >= maxlen {
+			il.CachedReply = append(il.CachedReply, strings.Join(cache, " "))
+			cache = make([]string, 0)
+			length = 0
+		}
+	}
+
+	if len(cache) > 0 {
+		il.CachedReply = append(il.CachedReply, strings.Join(cache, " "))
+	}
+}

--- a/irc/reply.go
+++ b/irc/reply.go
@@ -205,6 +205,14 @@ func (target *Client) RplMyInfo() {
 		target.server.name, SEM_VER, SupportedUserModes, SupportedChannelModes)
 }
 
+func (target *Client) RplISupport() {
+	for _, tokenline := range target.server.isupport.CachedReply {
+		target.NumericReply(RPL_ISUPPORT,
+			"%s :are supported by this server",
+			tokenline)
+	}
+}
+
 func (target *Client) RplUModeIs(client *Client) {
 	target.NumericReply(RPL_UMODEIS, client.ModeString())
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	signals   chan os.Signal
 	whoWas    *WhoWasList
 	theaters  map[Name][]byte
+	isupport  *ISupportList
 }
 
 var (
@@ -78,6 +79,17 @@ func NewServer(config *Config) *Server {
 	}
 
 	signal.Notify(server.signals, SERVER_SIGNALS...)
+
+	// add RPL_ISUPPORT tokens
+	//TODO(dan): Lots more tokens to support
+	server.isupport = NewISupportList()
+	server.isupport.Add("CASEMAPPING", "ascii")
+	server.isupport.Add("CHANTYPES", "#")
+	server.isupport.Add("EXCEPTS", "")
+	server.isupport.Add("INVEX", "")
+	server.isupport.Add("NETWORK", config.Network.Name)
+	server.isupport.Add("PREFIX", "(ov)@+")
+	server.isupport.RegenerateCachedReply()
 
 	return server
 }
@@ -258,6 +270,7 @@ func (s *Server) tryRegister(c *Client) {
 	c.RplYourHost()
 	c.RplCreated()
 	c.RplMyInfo()
+	c.RplISupport()
 	s.MOTD(c)
 }
 
@@ -693,6 +706,7 @@ func (msg *VersionCommand) HandleServer(server *Server) {
 	}
 
 	client.RplVersion()
+	client.RplISupport()
 }
 
 func (msg *InviteCommand) HandleServer(server *Server) {


### PR DESCRIPTION
This PR adds initial support for the [`RPL_ISUPPORT`](https://github.com/grawity/irc-docs/blob/master/client/RPL_ISUPPORT/draft-hardy-irc-isupport-00.txt) numeric, which is used by clients to get information about channel and client prefixes, as well as other data. It's a standard, used by basically every IRCd out there.

More tokens will be added, but as they require building other features I'd rather submit those in future PRs.
