### PR TITLE
Fix clients no longer being able to send commands after a single command errors out

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -73,12 +73,15 @@ func (client *Client) run() {
 		} else if command, err = ParseCommand(line); err != nil {
 			switch err {
 			case ErrParseCommand:
+				//TODO(dan): use the real failed numeric for this (400)
 				client.Reply(RplNotice(client.server, client,
 					NewText("failed to parse command")))
 
 			case NotEnoughArgsError:
 				// TODO
 			}
+			// so the read loop will continue
+			err = nil
 			continue
 
 		} else if checkPass, ok := command.(checkPasswordCommand); ok {


### PR DESCRIPTION
By default, if a single command fails to process the user can no longer send any commands, due to `err == nil` no longer being true. This fixes that issue, and fixes #23
